### PR TITLE
[fix] Hides unnecessary scrollbars for .highlight

### DIFF
--- a/_sass/fragaria/typography.scss
+++ b/_sass/fragaria/typography.scss
@@ -434,7 +434,7 @@ a {
 
     .highlight {
         background-color: $code-block-background-color;
-        overflow-x: scroll;
+        overflow-x: auto;
         line-height: 1rem;
         font-family: getFontFamily($monospacetype);
 


### PR DESCRIPTION
On https://fragaria.cz/blog/2018/09/03/building-a-simple-company-website-the-hard-way-typography-intro/#hyphens the code section gets unnecessary scrollbar (even doubled in this case):

![screenshot_2018-09-03_12-53-16](https://user-images.githubusercontent.com/375483/44983112-6037b500-af78-11e8-922d-000a12a795a1.png)


This PR fixes that while keeping the intended functionality (see https://fragaria.cz/blog/2018/02/05/mapujeme-adresy-do-ceskych-kraju/ with longer code sections)